### PR TITLE
Fix rules around rendering the rune spine

### DIFF
--- a/src/runes/RuneContainer.js
+++ b/src/runes/RuneContainer.js
@@ -73,17 +73,16 @@ export const RuneContainer = (props) => {
     focusProps
   } = useFocusRing({ within: true });
 
-  const topConsonant = (
+  const hasTopConsonant = (
     selectedKeys.has(RUNE_KEY.CTL)
     || selectedKeys.has(RUNE_KEY.CTT)
     || selectedKeys.has(RUNE_KEY.CTR)
   );
-  const bottomConsonant = (
-    selectedKeys.has(RUNE_KEY.CBL)
-    || selectedKeys.has(RUNE_KEY.CBB)
-    || selectedKeys.has(RUNE_KEY.CBR)
+  const hasTopSpine = selectedKeys.has(RUNE_KEY.CTT);
+  const hasBottomSpine = selectedKeys.has(RUNE_KEY.CBB);
+  const showSpine = hasTopSpine || (
+    hasTopConsonant && hasBottomSpine
   );
-  const spine = topConsonant && bottomConsonant;
 
   return (
     <div
@@ -102,7 +101,7 @@ export const RuneContainer = (props) => {
         ref={ref}
         className={'rune-pad__list'}
       >
-        {spine && (
+        {showSpine && (
           <div className={'rune-pad__line rune-pad__line--spine'} />
         )}
         {[...state.collection].map((item) => (


### PR DESCRIPTION
Sets the Rune to match the examples in this resource: https://tunic.wiki/books/faq/page/helpful-links

**Description of change:**
Altered the logic around when to show the rune spine in the component that renders out the Rune visually 